### PR TITLE
adds .zenodo.json draft

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC0-1.0",
     "contributors": [
         {
             "name": "Belle, Anna",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "license": "CC0-1.0",
+    "license": "CC-BY-NC-SA-4.0",
     "contributors": [
         {
             "name": "Belle, Anna",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -46,6 +46,12 @@
             "scheme": "url",
             "identifier": "https://github.com/Chorale-Corpus/Goudimel_C/tree/v2.1",
             "relation": "references"
+        },
+        {
+            "scheme": "doi",
+            "identifier": "10.5281/zenodo.17229783",
+            "relation": "isPartOf",
+            "resource_type":"dataset"
         }
     ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,20 +2,11 @@
     "license": "CC-BY-NC-SA-4.0",
     "contributors": [
         {
-            "name": "Belle, Anna",
-            "type": "Annotator",
-            "orcid": "0000-0000-0000-0000"
-        },
-        {
-            "name": "Daraud, Christine",
+            "orcid": "0000-0003-0722-3074",
             "type": "DataCurator",
-            "orcid": "0000-0000-0000-0000"
-        },
-        {
-            "name": "Fuhrmann, Erna",
-            "type": "DataCollector",
-            "orcid": "0000-0000-0000-0000"
-        }
+            "affiliation": "King's College London",
+            "name": "Gotham, Mark"
+        }        
     ],
     "title": "Goudimel, Claude – The Geneva Psalter (A chorale corpus)",
     "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,51 @@
+{
+    "license": "CC-BY-NC-SA-4.0",
+    "contributors": [
+        {
+            "name": "Belle, Anna",
+            "type": "Annotator",
+            "orcid": "0000-0000-0000-0000"
+        },
+        {
+            "name": "Daraud, Christine",
+            "type": "DataCurator",
+            "orcid": "0000-0000-0000-0000"
+        },
+        {
+            "name": "Fuhrmann, Erna",
+            "type": "DataCollector",
+            "orcid": "0000-0000-0000-0000"
+        }
+    ],
+    "title": "Goudimel, Claude – The Geneva Psalter (A chorale corpus)",
+    "keywords": [
+        "music research",
+        "music theory",
+        "music analysis",
+        "music history",
+        "corpus studies",
+        "corpora",
+        "multimodal dataset",
+        "symbolic dataset",
+        "scores",
+        "chorales"
+    ],
+    "upload_type": "dataset",
+    "version": "v2.1",
+    "publication_date": "2025-09-30",
+    "creators": [
+        {
+            "orcid": "0000-0003-0722-3074",
+            "affiliation": "King's College London",
+            "name": "Gotham, Mark"
+        }
+    ],
+    "access_right": "open",
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/Chorale-Corpus/Goudimel_C/tree/v2.1",
+            "relation": "references"
+        }
+    ]
+}


### PR DESCRIPTION
Once this is merged, it's gonna come public on Zenodo. The minimum metadata love the `.zenodo.json` should receive before merging is:

- relevant license
- relevant contributors
- relevant creators aka authors

Optionally, the best keywords out there.

Experience shows it's best to use a JSON linter because as much as a trailing comma will cause Zenodo to reject the release. The full json-schema for the Zenodo API can be found [here](https://github.com/johentsch/metadata-schema-zenodo/blob/main/schema.json). If in doubt, I'll be happy to review.